### PR TITLE
Except Java Language in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.java linguist-vendored


### PR DESCRIPTION
Now Java is not a Representative Language.